### PR TITLE
Cargo.toml: change althea_kernel_interface's path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jehan <jehan.tremback@gmail.com>"]
 
 [dependencies]
 babel_monitor = { path = "../babel_monitor" }
-althea_kernel_interface = { path = "../kernel_interface" }
+althea_kernel_interface = { path = "../althea_kernel_interface" }
 ip_network = "0.1"
 log = "0.3"
 docopt = "0.8.1"


### PR DESCRIPTION
This is a small page I proposed to @jtremback yesterday. There's more where this came from! :)